### PR TITLE
Correções de Assets

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@
 require 'capistrano/ext/multistage'
 require 'bundler/capistrano'
 require 'capistrano/maintenance'
-require 'capistrano_performance'
+require File.expand_path(File.join(File.dirname(__FILE__),'../lib/capistrano_performance'))
 
 set :stages, %w(prod1 prod2 prod3 prod4 prodspare prod_prod prod_todas hmg dev resque showroom new_machine apptest)
 


### PR DESCRIPTION
Fiz a substituição das chamadas /assets por chamadas diretas usando os digests
Tentei melhorar o deploy com:
- Adicionando o https://github.com/ndbroadbent/turbo-sprockets-rails3.
- Removendo a compilação sem digest.

Nenhuma dessas duas tentativas tiveram resultado satisfatório. O Turbo sprockets na verdade aumentou o tempo de deploy. Desconfiou que seja culpa dos assets sync mas não tenho certeza. 
Remover a compilação sem digest reduziu pouco e causou problemas no Rails ao requisitar um asset. Me parece que só após as duas compilações é que o manifest.yml é gerado e por isso causava erro. Investigarei mais posteriormente.

Adicionei então um script no capistrano para dar um report de performance ao final do deploy. De qualquer maneira um deploy no staging estava demorando cerca de 5 minutos.
