### PR TITLE
allows coupon by product to be applied only if the cart has the right product

### DIFF
--- a/app/helpers/cart_helper.rb
+++ b/app/helpers/cart_helper.rb
@@ -27,7 +27,7 @@ module CartHelper
   end
 
   def has_discount?(item)
-    @cart_service.item_promotion?(item) || cart_has_percentage_coupon? || item.price != item.retail_price
+    @cart_service.item_promotion?(item) || @cart.has_appliable_percentage_coupon? || item.price != item.retail_price
   end
 
   def show_checkout_banner?
@@ -49,16 +49,12 @@ module CartHelper
     def calculate_percentage_for item
       # for compatibility reason
 
-      if cart_has_percentage_coupon? && @cart.total_coupon_discount > @cart.total_promotion_discount
+      if @cart.has_appliable_percentage_coupon? && @cart.total_coupon_discount > @cart.total_promotion_discount
         @cart.coupon.value
       else
         item_retail_price = @cart_service.item_retail_price(item)
         (item.price - item_retail_price) / item.price * BigDecimal("100.0")
       end
-    end
-
-    def cart_has_percentage_coupon?
-      @cart.coupon && @cart.coupon.is_percentage?
     end
 
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -122,6 +122,14 @@ class Cart < ActiveRecord::Base
     Setting.valentines_day_coupon_code == (coupon_code)
   end
 
+  def has_appliable_percentage_coupon?
+    coupon && coupon.is_percentage? && items.select{|item| coupon.apply_discount_to?(item.product)}.any?
+  end
+
+  def has_coupon?
+    coupon && (!coupon.is_percentage? || has_appliable_percentage_coupon?)
+  end
+
   private
 
     def update_coupon

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -31,8 +31,8 @@ class CartItem < ActiveRecord::Base
   #
   def retail_price(options={})
     # coupon discount is calculated by cart service
-    if !options[:ignore_coupon] && cart.coupon
-      cart.coupon.is_percentage? ? price - (price * cart.coupon.value / 100) : price
+    if !options[:ignore_coupon] && cart.has_coupon?
+      cart.has_appliable_percentage_coupon? ? price - (price * cart.coupon.value / 100) : price
     else
       olooklet_value = variant.product.retail_price == 0 ? price : variant.product.retail_price
       promotional_value = price - adjustment_value / quantity.to_f if has_adjustment?

--- a/app/views/cart/cart/show.html.erb
+++ b/app/views/cart/cart/show.html.erb
@@ -169,7 +169,7 @@ _gaq.push(['_addTrans',
             </td>
             <td class="value discount">
               <p id="coupon_discount">
-                <% if @cart.coupon %>
+                <% if @cart.has_coupon? %>
                   <%= number_to_currency(@cart.total_coupon_discount) unless @cart.coupon.is_percentage? %>
                   <%= discount_percentage(@cart.coupon.discount_percent) %>
                 <% end %>
@@ -188,7 +188,7 @@ _gaq.push(['_addTrans',
           </tr>
         <tr class="total">
           <td>
-            <%- unless @cart.coupon -%>
+            <%- unless @cart.has_coupon? -%>
               <table id="coupon" cellpadding="0" cellspacing="0">
                 <tbody>
                   <tr class="discount">

--- a/app/views/cart/items/destroy.js.erb
+++ b/app/views/cart/items/destroy.js.erb
@@ -38,5 +38,13 @@ $("li[data-id=<%= @item.id %>]").first().remove();
 $(".checkout_banner").remove();
 $("#items").after("<%= escape_javascript(render 'cart/cart/checkout_banner') %>");
 
+// update coupon
+$("#coupon_discount").remove();
+<% if @cart.has_coupon? %>
+  $("#coupon_discount").text("<%= number_to_currency(@cart.total_coupon_discount) unless @cart.coupon.is_percentage? %>");
+  $("#coupon_discount").text("<%= discount_percentage(@cart.coupon.discount_percent) %>");               
+<% end %>
+
+
 
 


### PR DESCRIPTION
Estavamos com um bug no cupom especifico por produto. Resolvi, porém seria bom testar melhor o fluxo de compra inserindo e removendo cupons (fiz testes apenas com o cupom de porcentagem).

Uma issue conhecida é, na sacola, caso tenha cupom, se clicar no link excluir (para remover o cupom) o campo para digitar o cupom nao aparece, sendo necessario um refresh na pagina. Mas isso pode deixar assim por enquanto.

@tigluiz, Tem as moral de validar ?
