### PR TITLE
add new field to store facebook likes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 class User < ActiveRecord::Base
   serialize :facebook_permissions, Array
   serialize :facebook_data, Hash
+  serialize :facebook_likes, Array
 
   attr_accessor :require_cpf, :validate_gender_birthday
   attr_accessible :first_name, :last_name, :email, :password,

--- a/app/services/facebook_connect_service.rb
+++ b/app/services/facebook_connect_service.rb
@@ -13,9 +13,13 @@ class FacebookConnectService
     fb_api('/me', @access_token)
   end
 
+  def get_facebook_likes(facebook_token)
+    # Tem que usar o Koala, pq pela API o nosso facebook_token nao funciona para obter os likes
+    FacebookAdapter.new(facebook_token).adapter.get_connections('me', 'likes').try(:to_a) || []
+  end
+
   def connect!
-    @facebook_data = get_facebook_data
-    
+    @facebook_data = get_facebook_data   
     Rails.logger.info("[FACEBOOK] Retrieved data from facebook:#{@facebook_data}")
     
     if(@facebook_data.respond_to?(:[]) && @facebook_data['error'])
@@ -35,6 +39,9 @@ class FacebookConnectService
       @user = create_user
       @user.add_event(EventType::FACEBOOK_CONNECT)
     end
+
+    facebook_likes = get_facebook_likes(@user.facebook_token)
+    @user.update_attribute(:facebook_likes, facebook_likes)
     return true
   end
 

--- a/db/migrate/20140522171025_add_facebook_likes_to_users.rb
+++ b/db/migrate/20140522171025_add_facebook_likes_to_users.rb
@@ -1,0 +1,5 @@
+class AddFacebookLikesToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :facebook_likes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140517173814) do
+ActiveRecord::Schema.define(:version => 20140522171025) do
 
   create_table "action_parameters", :force => true do |t|
     t.integer  "matchable_id"
@@ -212,7 +212,6 @@ ActiveRecord::Schema.define(:version => 20140517173814) do
   add_index "carts", ["address_id"], :name => "index_carts_on_address_id"
   add_index "carts", ["coupon_id"], :name => "index_carts_on_coupon_id"
   add_index "carts", ["notified"], :name => "index_carts_on_notified"
-  add_index "carts", ["user_id"], :name => "index_carts_on_user_id"
 
   create_table "carts_backup", :id => false, :force => true do |t|
     t.integer  "id",                      :default => 0,     :null => false
@@ -1079,18 +1078,11 @@ ActiveRecord::Schema.define(:version => 20140517173814) do
 
   add_index "rule_parameters", ["matchable_id", "matchable_type"], :name => "index_rule_parameters_on_matchable_id_and_matchable_type"
 
-  create_table "seo_links", :force => true do |t|
-    t.string   "name"
-    t.string   "path"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
   create_table "sessions", :force => true do |t|
     t.string   "session_id", :null => false
     t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
@@ -1280,6 +1272,7 @@ ActiveRecord::Schema.define(:version => 20140517173814) do
     t.string   "fantasy_name"
     t.integer  "orders_count",                                    :default => 0
     t.text     "facebook_data"
+    t.text     "facebook_likes"
   end
 
   add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token"


### PR DESCRIPTION
Além de armazenar os dados publicos do facebook, também vamos armazenar os likes, porém, a nossa permissao do FB nao permite obter os likes via Graph API, mas via Koala deu certo. Vai entender...

@nelsonmhjr , @luisdaher , @tigluiz dêem uma olhada por favor. Como tem migration na tabela users, vou fazer de madrugada esse deploy
