### PR TITLE
Continuar Comprando para uma url mais interessante

### DIFF
--- a/app/controllers/cart/cart_controller.rb
+++ b/app/controllers/cart/cart_controller.rb
@@ -25,6 +25,8 @@ class Cart::CartController < ApplicationController
       @promo_over_coupon = true
     end
 
+    @return_url = session[:search_url] || catalog_url((@cart.items.first.try(:product).try(:category_humanize) || 'sapato').parameterize)
+
     @freebie = Freebie.new(subtotal: @cart.sub_total, cart_id: @cart.id)
 
     respond_to do |format|

--- a/app/views/cart/cart/show.html.erb
+++ b/app/views/cart/cart/show.html.erb
@@ -188,7 +188,7 @@ _gaq.push(['_addTrans',
       <tbody>
         <tr>
           <td class="buy-link">
-            <p class="buying-continue"><%= link_to "<< Continuar comprando","/colecoes" %></p>
+            <p class="buying-continue"><%= link_to "<< Continuar comprando", @return_url %></p>
           </td>
           <td class="buttons">
             <% if current_user && !current_user.reseller %>


### PR DESCRIPTION
A idéia é ter uma url mais interessante no link de continuar comprando da sacola.
Hoje leva a coleções.

Com essa feature, deve levar para a última página de listagem de produtos que a pessoa visitou. 

Se o usuário não tiver passado por nenhuma página de listagem de produtos, a pessoa caiu no site na home e colocou na sacola um produto de lá por ex., vai para a página de catalogo do primeiro produto na sacola.

@tigluiz @luisdaher ou @darkseid 
pls validem!

Fiz os testes (manuais) e funciona que é uma beleza.
